### PR TITLE
Various edits

### DIFF
--- a/content/pages/appinfo.md
+++ b/content/pages/appinfo.md
@@ -77,6 +77,14 @@ Default: `true` for Developer Mode apps; `false` otherwise
 
 Allows this app to be debugged using Chrome DevTools (`chrome://inspect`). Connect on port 9998 for non-system apps.
 
+## `useCORSWhitelist` [string]
+Specifies the name of a JSON file containing a
+[CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing)
+whitelist configuration. A matching signature file (with the same filename
+followed by `.sig`) is required. The signature is Base64-encoded, with the
+underlying binary data being 256 bytes long. The signature algorithm is
+currently unknown.
+
 ## `vendorExtensions` [object]
 
 ### `vendorExtensions.userAgent` [string]

--- a/content/pages/index.md
+++ b/content/pages/index.md
@@ -15,7 +15,7 @@ development for LG webOS Smart TV platform.
 
 Our main points of interest are:
 
-* Building [an unofficial native app toolchain](https://github.com/webosbrew/meta-lg-webos-ndk)
+* Building [an unofficial native app toolchain](https://github.com/webosbrew/native-toolchain)
 * Reverse engineering and documenting [native system APIs](https://github.com/webosbrew/tv-native-apis) and other
   undocumented features
 * Maintaining an independent [repository of unofficial applications](https://github.com/webosbrew/apps-repo) and

--- a/content/pages/index.md
+++ b/content/pages/index.md
@@ -42,7 +42,7 @@ exploit. [Homebrew Channel](https://github.com/webosbrew/webos-homebrew-channel)
 is a user friendly unofficial "application store".
 
 If your TV is not vulnerable to the RootMyTV exploit chain, you can still
-[enable Developer Mode](https://webostv.developer.lge.com/develop/app-test/using-devmode-app/) on a TV and then use
+[enable Developer Mode](https://webostv.developer.lge.com/develop/getting-started/developer-mode-app) on a TV and then use
 our [Device Manager app](https://github.com/webosbrew/dev-manager-desktop).
 
 Keep in mind this has the downside of requiring "Developer Mode Session" renewal in the "Developer Mode" app every 1000 hours.

--- a/content/pages/index.md
+++ b/content/pages/index.md
@@ -15,7 +15,7 @@ development for LG webOS Smart TV platform.
 
 Our main points of interest are:
 
-* Building [an unofficial native app toolchain](https://github.com/webosbrew/native-toolchain)
+* Building an [unofficial native toolchain](https://github.com/webosbrew/native-toolchain)
 * Reverse engineering and documenting [native system APIs](https://github.com/webosbrew/tv-native-apis) and other
   undocumented features
 * Maintaining an independent [repository of unofficial applications](https://github.com/webosbrew/apps-repo) and
@@ -31,8 +31,8 @@ Our main points of interest are:
 Our community has some overlap with [RootMyTV](https://rootmy.tv) and [OpenLGTV](https://openlgtv.github.io) teams, but
 each has its distinct purpose (root access exploitation and low level hardware reversing, respectively).
 
-Our main points of contact are [#homebrew channel on OpenLGTV Discord](https://discord.gg/nKQW6FPWeM)
-and [#openlgtv:netserve.live](https://matrix.to/#/#openlgtv:netserve.live) Matrix channel.
+Our main points of contact are the [#homebrew channel on OpenLGTV Discord](https://discord.gg/nKQW6FPWeM)
+and the [#openlgtv:netserve.live](https://matrix.to/#/#openlgtv:netserve.live) Matrix channel.
 
 ## Getting Started
 
@@ -46,8 +46,9 @@ If your TV is not vulnerable to the RootMyTV exploit chain, you can still
 our [Device Manager app](https://github.com/webosbrew/dev-manager-desktop).
 
 Keep in mind this has the downside of requiring "Developer Mode Session" renewal in the "Developer Mode" app every 1000 hours.
-Alternatively, if you are technically profficient, a machine in a local network can periodically refresh the token for you
-using a script [like one of these](https://github.com/webosbrew/dev-goodies/blob/main/reset-devmode-timer.sh).
+Alternatively, if you are technically proficient, you can have a machine on your
+local network periodically refresh the token for you
+using a script like [this one](https://github.com/webosbrew/dev-goodies/blob/main/reset-devmode-timer.sh).
 
 ## Find Apps
 
@@ -57,7 +58,7 @@ by default.
 
 ## For Developers
 
-* [Configuring SDK]({filename}/pages/sdk.md)
+* [SDK configuration]({filename}/pages/sdk.md)
 * [Native development]({filename}/pages/native.md)
 * [Web development]({filename}/pages/web.md)
 * Hacking

--- a/content/pages/logging.md
+++ b/content/pages/logging.md
@@ -1,17 +1,17 @@
 Title: Logging
 
-Logging on webOS TV is handled by `PmLogDaemon` service. It is similar to most
+Logging on webOS is handled by the `PmLogDaemon` service. It is similar to most
 other system logging daemons. Most log messages are dumped into
-`/var/log/messages` (though some are routed into different paths - see
-configuration in `/etc/pmlog.d/`)
+`/var/log/messages` or `/var/log/legacy-log`, though some are routed into different paths&mdash;see
+configuration in `/etc/pmlog.d/`.
 
-By default, on retail software, only messages of certain types from specific
-sources are logged into a file - configured in `/etc/PmLogDaemon/whitelist.txt`.
+By default on production webOS, only messages of certain types from specific
+sources may be logged to a file. Allowed messages are configured in `/etc/PmLogDaemon/whitelist.txt`.
 
-In order to disable log whitelisting certain luna calls need to be executed.
+You can disable log whitelisting by executing certain luna calls:
 ```sh
 # webOS 4.x+
-luna-send -n 1 -f luna://com.webos.service.config/setConfigs '{"configs": {"system.collectDevLogs": true}}'
+luna-send -n 1 -f luna://com.webos.service.config/setConfigs '{"configs":{"system.collectDevLogs":true}}'
 
 # webOS 3.x and older
 luna-send -n 1 -f 'luna://com.webos.pmlogd/setdevlogstatus' '{"recordDevLogs":true}'
@@ -30,30 +30,31 @@ PmLogCtl set WAM debug
 PmLogCtl set '*' none
 ```
 
-Then logs can be viewed by running:
+Logs can be viewed by running:
 ```sh
 tail -F /var/log/messages
 ```
 
-Keep in mind `/var/log/messages` file is rotated, thus setting too high logging
-level may cause it to drop messages (even when using `-F` flag)
+Keep in mind that most log files (including `/var/log/messages`) are rotated,
+and therefore setting too high of a logging level may cause you to miss
+messages (even when using the `-F` flag).
 
 ## PmLogLib stub
 Alternatively (on non-rooted devices) a
-[PmLogLib library stub](https://github.com/webosbrew/meta-lg-webos-ndk#system-library-logging) can be used that will print out logs into standard output.
+[PmLogLib library stub](https://github.com/webosbrew/meta-lg-webos-ndk#system-library-logging) can be used that will print out logs to standard output.
 
-## Crashlogs
+## Crash logs
 Crash logs are dumped into `/var/log/reports/librdx/` or
 `/tmp/faultmanager/crash/`. These are gzipped text files containing process
-information, memory maps, backtrace and some memory dumps. These *are*
-automatically reported to LG unless `rdxd` is locked up (like what
-rootmy.tv/homebrew channel does on startup)
+information, memory maps, backtraces, and some memory dumps. These *are*
+automatically reported to LG unless `rdxd` is blocked (as
+Homebrew Channel does on startup).
 
-Crashes may also cause alert popups on screen if system is running in DEBUG
+Crashes may also cause alert popups on screen if the system is running in DEBUG
 mode.
 
-Crashlog dumping can be disabled by settings `SEGFAULT_SIGNALS` to empty string
-before launch, like so:
+Crash log dumping can be disabled by setting the `SEGFAULT_SIGNALS` environment
+variable to an empty string before launch, like so:
 ```sh
 SEGFAULT_SIGNALS= ./buggy-binary
 ```

--- a/content/pages/sdk.md
+++ b/content/pages/sdk.md
@@ -13,7 +13,7 @@ functionality is accessible via root SSH server exposed by Homebrew Channel, and
 installing it will probably break root startup sequence.
 
 ## Configuring @webosose/ares-cli with Developer Mode App
-This is partially based on: https://webostv.developer.lge.com/develop/app-test/using-devmode-app/
+This is partially based on: https://webostv.developer.lge.com/develop/getting-started/developer-mode-app
 
 1. Install Developer Mode app from Content Store
 2. Enable developer mode, enable keyserver

--- a/content/pages/sdk.md
+++ b/content/pages/sdk.md
@@ -1,22 +1,22 @@
-Title: Configuring SDK
+Title: SDK configuration
 status: hidden
 
 # Development TV setup
 
-Recommended tooling for webOS TV development is
+The recommended tooling for webOS TV development is
 [@webosose/ares-cli](https://www.npmjs.com/package/@webosose/ares-cli) NPM
 package. It provides all the basic tools without needing to install them
 globally.
 
-**If your TV is rooted** You *shall not* use "Developer Mode" app - all of its
-functionality is accessible via root SSH server exposed by Homebrew Channel, and
-installing it will probably break root startup sequence.
+**If your TV is rooted** you *must not* use LG's "Developer Mode" app; installing it
+will probably break your system, potentially necessitating a factory reset. All of its
+functionality (e.g., SSH access) is replaced by Homebrew Channel.
 
 ## Configuring @webosose/ares-cli with Developer Mode App
-This is partially based on: https://webostv.developer.lge.com/develop/getting-started/developer-mode-app
+This is partially based on [LG's instructions](https://webostv.developer.lge.com/develop/getting-started/developer-mode-app).
 
 1. Install Developer Mode app from Content Store
-2. Enable developer mode, enable keyserver
+2. Enable developer mode; enable keyserver
 3. Download TV's private key: `http://TV_IP:9991/webos_rsa` and save under `$HOME/.ssh`
 4. As with any SSH key, restrict its access rights: `chmod 600 ~/.ssh/webos_rsa`
 5. You can test the key with: `ssh-keygen -y -P "PASSPHRASE" -f ~/.ssh/webos_rsa`
@@ -37,7 +37,7 @@ ares-setup-device -a webos -i "username=root" -i "privatekey=id_rsa" -i "passphr
 
 **Note:** @webosose/ares-cli doesn't need to be installed globally - you can use a package installed in a local project directory by just prefixing above commands with local path, like so: `node_modules/.bin/ares-setup-device ...`
 
-## Configuring VSCode Extension
+## Configuring VS Code Extension
 1. Load https://marketplace.visualstudio.com/items?itemName=webOSOSESDK.webosose into your VSCode
 2. The Extension will prompt you to install needed npm Packages. This will probably fail depending on your VSCode setup due to permissions - run the commands manually in a root shell (```npm install @webosose/ares-cli```)
 3. Setup Key auth with your TV

--- a/content/pages/web.md
+++ b/content/pages/web.md
@@ -4,51 +4,52 @@ Title: Web development
 * [webOS
   TV](https://webostv.developer.lge.com/develop/overview/building-your-first-web-app-webos-tv/)
 
-# Developer Toolbar
-Web applications on webOS can be inspected using "Developer Toolbar", equivalent
-to the one present in modern browsers.
+# DevTools
+Web applications on webOS can be inspected using Chromium [DevTools](https://developer.chrome.com/docs/devtools/), equivalent
+to the functionality present in modern browsers.
 
-This can be accessed using some different methods:
+This can be accessed using various methods:
 
 1. Running `ares-inspect APPID` with [SDK set up]({filename}/pages/sdk.md)
 2. Directly accessing `http://TV_IP:9998` from a browser (equivalent to method
    1, but does not require SDK)
-3. Adding `TV_IP:9998` as a "Remote Target" in `chrome://inspect` in Chrome-based
+3. Adding `TV_IP:9998` as a "Remote Target" in `chrome://inspect` in Chromium-based
    browsers.
 
-All these methods have some limitations in case of older webOS versions. For
-example - on webOS 3.8 methods 1 and 2:
+All these methods have some limitations on older webOS versions. For
+example, using methods 1 and 2 on webOS 3.8:
 
-* Dev toolbar fails completely when opened in Chromium 96 (only top tab bar is
+* DevTools fails completely when opened in Chromium 96 (only top tab bar is
   rendered)
 * "Console" is not scrollable and code cannot be injected when running in
   Firefox 94
-* Works mostly fine in Midori 9.0 (webkitGTK-based browser on Linux)
+* Works mostly fine in Midori 9.0 (WebKitGTK-based browser on Linux)
 
-Option 3 works fine, but code execution in "Console" tab does not work and
-preview window seems corrupted. This also may trigger WAM crash sometimes for
-some reason.
+Option 3 works fine, but code execution in the "Console" tab does not work and the
+preview window seems corrupted. This also may sometimes trigger a WAM crash for
+unknown reasons.
 
 # Undocumented features
 
 ## Input/TV embedding
 
-Web apps can embed connected inputs surface in their DOM:
+Web apps can embed connected external input sources in their DOM:
 ```html
 <video autoplay style="width:50%;height:50%">
   <source type="service/webos-external" src="ext://hdmi:1"></source>
 </video>
 ```
 Supported sources: `ext://hdmi:1`, `ext://hdmi:2`, `ext://hdmi:3`, `ext://hdmi:4`, `ext://comp:1`, `ext://av:1`, `ext://av:2`.
-Additionally TV stream can be embedded with `src="tv://"` and `type="service/webos-broadcast"`
+Additionally, a TV stream can be embedded with `src="tv://"` and `type="service/webos-broadcast"`
 
-Seems like only a single external input can be displayed at the same time. (though, this may be a dependednt on used hardware)
+It seems like only a single external input can be displayed at the same time
+(though this may be hardware-dependent).
 
-This also works partially in system browser (content is cut off whenever status
-bar is visible), but one probably should not rely on this.
+This also partially works in the system browser (content is cut off whenever the
+status bar is visible), but one probably should not rely on this.
 
 ## Userscripts in apps
-Userscript present in [`webOSUserScripts/userScript.js`](https://github.com/webosose/wam/blob/f7c68dbeb744e8af66e4a83507b3d429dd692b2f/src/core/WebAppManagerConfig.cpp#L71-L73)
+JavaScript present in [`webOSUserScripts/userScript.js`](https://github.com/webosose/wam/blob/f7c68dbeb744e8af66e4a83507b3d429dd692b2f/src/core/WebAppManagerConfig.cpp#L71-L73)
 will be [loaded as a userscript](https://github.com/webosose/wam/blob/f7c68dbeb744e8af66e4a83507b3d429dd692b2f/src/core/WebPageBase.cpp#L476-L486)
 in app webviews / frames, including frames in origins outside of app root.
 

--- a/content/pages/web.md
+++ b/content/pages/web.md
@@ -29,6 +29,15 @@ Option 3 works fine, but code execution in the "Console" tab does not work and t
 preview window seems corrupted. This also may sometimes trigger a WAM crash for
 unknown reasons.
 
+## Chromium versions
+Some of the issues encountered using DevTools on older webOS versions may be
+resolved by using an older release of Chromium. Specifically, according to
+[LG's App Debugging documentation](https://webostv.developer.lge.com/develop/getting-started/app-debugging),
+the supported versions are:
+* webOS 1&ndash;3: Chrome 38
+* webOS 4&ndash;5: Chrome 68
+* webOS 6+: latest version
+
 # Undocumented features
 
 ## Input/TV embedding
@@ -55,3 +64,15 @@ in app webviews / frames, including frames in origins outside of app root.
 
 Example application that uses this:
 [webosbrew/youtube-webos](https://github.com/webosbrew/youtube-webos)
+
+## Inspecting non-developer apps
+Apps installed from the Content Store (generally found under `/media/cryptofs`)
+are not inspectable by default. You can make an app inspectable by adding
+`"inspectable":true` to its `appinfo.json`.
+
+## Inspecting system apps
+It is possible to inspect system apps (i.e., those found in
+`/usr/palm/applications`) on port 9999. However, this is not enabled by
+default. While creating the file `/var/luna/preferences/debug_system_apps`
+should enable it, our current method of maintaining root access creates issues
+that require additional workarounds.


### PR DESCRIPTION
* Added information about inspecting system/non-dev mode aps
* Added `useCORSWhitelist` `appinfo.json` property
* Updated links
  * Fix broken LG documentation links
  * Link to [native-toolchain](https://github.com/webosbrew/native-toolchain) instead of [meta-lg-webos-ndk](https://github.com/webosbrew/meta-lg-webos-ndk)
* Various grammar/style edits